### PR TITLE
remove manual value for --max-itrs

### DIFF
--- a/src/data_model/SNPStorage.ipp
+++ b/src/data_model/SNPStorage.ipp
@@ -170,7 +170,7 @@ namespace epi {
                 break;
             case options::EpistasisScore::REGRESSION_NLL_GAIN:
                 if (regression_model_scores[current_thread] != score) {
-                    regression_models[current_thread]->set_options("--score NLL-GAIN --max-itrs 50000");
+                    regression_models[current_thread]->set_options("--score NLL-GAIN");
                     regression_model_scores[current_thread] = score;
                 }
                 break;


### PR DESCRIPTION
Remove temporary flag that increases max-itrs for the Regression NLL-gain
--> Does model run until convergence now?